### PR TITLE
feat: Add local file caching for articles

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 import cors from "cors";
 import "dotenv/config";
 import express, { json } from "express";
+import fs from "fs/promises"; // Added fs/promises import
 import { MongoClient } from "mongodb"; // Added MongoDB import
 import { emailTemplate } from "./template/EmailTemplate.js";
 const app = express();
+
+const CACHE_FILE_PATH = "./articles_cache.json"; // Defined cache file path
 
 const RESEND_API_KEY = process.env.RESEND_API_KEY;
 const API_SECRET_KEY = process.env.API_SECRET_KEY;
@@ -32,20 +35,45 @@ app.get("/api/hn-articles", async (req, res) => {
     // Fetch all articles, sorted by scrapedAt descending if needed, or by sourceName
     const articlesFromDB = await collection.find({}).sort({ _id: 1 }).toArray();
 
-    // Group articles by sourceName for the frontend
-    const articlesBySource = articlesFromDB.reduce((acc, article) => {
-      const { sourceName, ...rest } = article;
-      if (!acc[sourceName]) {
-        acc[sourceName] = [];
-      }
-      acc[sourceName].push(rest);
-      return acc;
-    }, {});
+    if (articlesFromDB && articlesFromDB.length > 0) {
+      // Group articles by sourceName for the frontend
+      const articlesBySource = articlesFromDB.reduce((acc, article) => {
+        const { sourceName, ...rest } = article;
+        if (!acc[sourceName]) {
+          acc[sourceName] = [];
+        }
+        acc[sourceName].push(rest);
+        return acc;
+      }, {});
 
-    res.json(articlesBySource);
-  } catch (err) {
-    console.error("Failed to fetch articles from MongoDB:", err);
-    res.status(500).json({ error: "Could not load articles from database." });
+      // Save to cache
+      fs.writeFile(CACHE_FILE_PATH, JSON.stringify(articlesBySource))
+        .then(() => console.log("Articles cached successfully."))
+        .catch(cacheWriteErr => console.error("Cache write error:", cacheWriteErr)); // Log cache write error but don't block response
+
+      return res.json(articlesBySource); // Respond with DB data even if cache write fails
+    } else {
+      // Handle empty articlesFromDB by attempting to read from cache
+      console.log("No articles fetched from MongoDB, attempting to read from cache.");
+      throw new Error("No articles from DB"); // Trigger catch block for cache fallback
+    }
+  } catch (dbOrLogicErr) { // Renamed to clarify this catches DB errors or the "No articles from DB" error
+    console.error("MongoDB fetch error or initial logic failure:", dbOrLogicErr.message);
+    try {
+      console.log("Attempting to serve articles from cache due to previous error.");
+      const cachedData = await fs.readFile(CACHE_FILE_PATH, 'utf-8');
+      try {
+        const cachedArticles = JSON.parse(cachedData);
+        console.log("Serving articles from cache.");
+        return res.json(cachedArticles);
+      } catch (parseErr) {
+        console.error("Cache parse error:", parseErr);
+        return res.status(500).json({ error: "Could not load articles from database or cache." });
+      }
+    } catch (cacheReadErr) {
+      console.error("Cache read error:", cacheReadErr);
+      return res.status(500).json({ error: "Could not load articles from database or cache." });
+    }
   } finally {
     if (mongoClient) {
       await mongoClient.close();


### PR DESCRIPTION
I've implemented a caching mechanism for the /api/hn-articles endpoint.

- When articles are successfully fetched from MongoDB, they are now also written to a local articles_cache.json file.
- If fetching from MongoDB fails (either due to an error or if no articles are returned), I will attempt to serve articles from articles_cache.json.
- I've added error handling for cache read/write operations. Cache write errors do not disrupt the primary response if MongoDB data is available.
- If both MongoDB and the local cache are unavailable or return invalid data, the API will respond with a 500 status and a consistent error message: "Could not load articles from database or cache."
- The articles_cache.json file is covered by .gitignore.

This change improves the resilience of the articles endpoint by providing a fallback data source if the primary MongoDB database is inaccessible.