### PR TITLE
Refactor: Use JSON response instead of streaming in /api/chat

### DIFF
--- a/index.js
+++ b/index.js
@@ -180,7 +180,8 @@ app.post("/api/chat", async (req, res) => {
       //   }),
       // },
     });
-    result.pipeTextStreamToResponse(res);
+    const text = await result.text();
+    res.json({ response: text });
   } catch (error) {
     console.error("Error in /api/chat:", error);
     res.status(500).send(`Error: ${error.message || "An unknown error occurred"}`);


### PR DESCRIPTION
I changed the /api/chat route to wait for the full response from the AI model and send it as a JSON object. This replaces the previous streaming implementation.